### PR TITLE
Fix incorrect usage of `sync.WaitGroup` in `RulesFromFile`

### DIFF
--- a/difflint.go
+++ b/difflint.go
@@ -107,6 +107,9 @@ func Lint(o LintOptions) (*LintResult, error) {
 		return nil, errors.Wrap(err, "failed to parse rules from hunks")
 	}
 
+	// TODO: This is for testing. Delete this.
+	log.Println("rulesMap:", rulesMap)
+
 	// Collect the rules that are not satisfied.
 	unsatisfiedRules, err := Check(rulesMap)
 	if err != nil {

--- a/difflint.go
+++ b/difflint.go
@@ -107,9 +107,6 @@ func Lint(o LintOptions) (*LintResult, error) {
 		return nil, errors.Wrap(err, "failed to parse rules from hunks")
 	}
 
-	// TODO: This is for testing. Delete this.
-	log.Println("rulesMap:", rulesMap)
-
 	// Collect the rules that are not satisfied.
 	unsatisfiedRules, err := Check(rulesMap)
 	if err != nil {

--- a/rules.go
+++ b/rules.go
@@ -126,5 +126,11 @@ func RulesFromFile(pathname string, ranges []Range, visited map[string]struct{},
 		}
 	}
 
+	// Print every rule.
+	for _, rule := range rules {
+		log.Println("Parsed rule:", rule)
+	}
+	// TODO: This is for testing. Delete this.
+
 	return rules, nil
 }

--- a/rules.go
+++ b/rules.go
@@ -102,21 +102,22 @@ func RulesFromFile(pathname string, ranges []Range, visited map[string]struct{},
 		return nil, errors.Wrapf(err, "failed to parse rules for file %s", pathname)
 	}
 
+	var innerWg sync.WaitGroup // WaitGroup for inner goroutines
 	for _, rule := range rules {
 		for _, target := range rule.Targets {
 			if target.File == nil {
 				continue
 			}
 
-			wg.Add(1)
+			innerWg.Add(1)
 			go func(pathname string) {
-				defer wg.Done()
+				defer innerWg.Done()
 
 				if _, ok := visited[pathname]; ok {
 					return
 				}
 
-				moreRules, err := RulesFromFile(pathname, nil, visited, wg, options)
+				moreRules, err := RulesFromFile(pathname, nil, visited, &innerWg, options)
 				if err != nil {
 					return
 				}
@@ -125,6 +126,9 @@ func RulesFromFile(pathname string, ranges []Range, visited map[string]struct{},
 			}(*target.File)
 		}
 	}
+
+	// Wait for all inner goroutines to complete before returning.
+	innerWg.Wait()
 
 	// Print every rule.
 	for _, rule := range rules {

--- a/rules.go
+++ b/rules.go
@@ -130,11 +130,6 @@ func RulesFromFile(pathname string, ranges []Range, visited map[string]struct{},
 	// Wait for all inner goroutines to complete before returning.
 	innerWg.Wait()
 
-	// Print every rule.
-	for _, rule := range rules {
-		log.Println("Parsed rule:", rule)
-	}
-	// TODO: This is for testing. Delete this.
-
+	// Add rules to the map.
 	return rules, nil
 }


### PR DESCRIPTION
This PR fixes the incorrect usage of `sync.WaitGroup` in the `RulesFromFile` function. The previous implementation resulted in improper synchronization of goroutines and potential race conditions. The fix introduces a separate `innerWg` WaitGroup to track the completion of inner goroutines, ensuring proper synchronization and preventing premature completion of the outer WaitGroup.

Resolves #6.