### PR TITLE
`Do`: Return tuple `([]UnsatisfiedRule, error)`

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -77,7 +77,7 @@ func action(ctx *cli.Context) error {
 	extMapPath := ctx.String("ext_map")
 
 	if err := difflint.Do(ctx.App.Reader, include, exclude, extMapPath); err != nil {
-		return err
+		log.Fatalln(err)
 	}
 
 	return nil

--- a/cli/main.go
+++ b/cli/main.go
@@ -82,7 +82,7 @@ func action(ctx *cli.Context) error {
 	}
 
 	if len(unsatisfiedRules) > 0 {
-		return cli.Exit("Lint failed", 1)
+		return cli.Exit(unsatisfiedRules.String(), 1)
 	}
 
 	return nil

--- a/cli/main.go
+++ b/cli/main.go
@@ -76,8 +76,8 @@ func action(ctx *cli.Context) error {
 	exclude := ctx.StringSlice("exclude")
 	extMapPath := ctx.String("ext_map")
 
-	if err := difflint.Do(ctx.App.Reader, include, exclude, extMapPath); err != nil {
-		log.Fatalln(err)
+	if _, err := difflint.Do(ctx.App.Reader, include, exclude, extMapPath); err != nil {
+		return err
 	}
 
 	return nil

--- a/cli/main.go
+++ b/cli/main.go
@@ -76,8 +76,13 @@ func action(ctx *cli.Context) error {
 	exclude := ctx.StringSlice("exclude")
 	extMapPath := ctx.String("ext_map")
 
-	if _, err := difflint.Do(ctx.App.Reader, include, exclude, extMapPath); err != nil {
+	unsatisfiedRules, err := difflint.Do(ctx.App.Reader, include, exclude, extMapPath)
+	if err != nil {
 		return err
+	}
+
+	if len(unsatisfiedRules) > 0 {
+		return cli.Exit("Lint failed", 1)
 	}
 
 	return nil

--- a/difflint.go
+++ b/difflint.go
@@ -176,8 +176,8 @@ func isRelativeToCurrentDirectory(path string) bool {
 }
 
 // Check returns the list of unsatisfied rules for the given map of rules.
-func Check(rulesMap map[string][]Rule) ([]UnsatisfiedRule, error) {
-	var unsatisfiedRules []UnsatisfiedRule
+func Check(rulesMap map[string][]Rule) (UnsatisfiedRules, error) {
+	var unsatisfiedRules UnsatisfiedRules
 	for pathnameA, rulesA := range rulesMap {
 	outer:
 		for i, ruleA := range rulesA {

--- a/difflint.go
+++ b/difflint.go
@@ -193,7 +193,7 @@ func Check(rulesMap map[string][]Rule) ([]UnsatisfiedRule, error) {
 }
 
 // Entrypoint for the difflint command.
-func Do(r io.Reader, include, exclude []string, extMapPath string) error {
+func Do(r io.Reader, include, exclude []string, extMapPath string) ([]UnsatisfiedRule, error) {
 	// Parse options.
 	extMap := NewExtMap(extMapPath)
 
@@ -207,19 +207,19 @@ func Do(r io.Reader, include, exclude []string, extMapPath string) error {
 		FileExtMap:      extMap.FileExtMap,
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to lint hunks")
+		return nil, errors.Wrap(err, "failed to lint hunks")
 	}
 
 	// If there are no unsatisfied rules, return nil.
 	if len(result.UnsatisfiedRules) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Print the unsatisfied rules.
 	for _, rule := range result.UnsatisfiedRules {
 		// Skip if the rule is not intended to be included in the output.
 		if ok, err := Include(rule.Hunk.File, include, exclude); err != nil {
-			return errors.Wrap(err, "failed to check if file is included")
+			return nil, errors.Wrap(err, "failed to check if file is included")
 		} else if !ok {
 			continue
 		}
@@ -238,7 +238,7 @@ func Do(r io.Reader, include, exclude []string, extMapPath string) error {
 		}
 	}
 
-	return nil
+	return result.UnsatisfiedRules, nil
 }
 
 // ParseHunks parses the input diff and returns the extracted file paths along


### PR DESCRIPTION
`difflint.Do` should return a list of unsatisfied rules.